### PR TITLE
Add Option To Retain FO

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ configure(rootproject) {
 
         // Configure which files have ${} expanded
         expandPlaceholders = '**/index.xml, **/other.xml'
+        
+        // Delete the index.fo after creating PDF
+        retainFo = false
     }
 
     task docsZip(type: Zip) {

--- a/src/main/groovy/DocbookReferencePlugin.groovy
+++ b/src/main/groovy/DocbookReferencePlugin.groovy
@@ -61,6 +61,7 @@ class DocbookReferencePlugin implements Plugin<Project> {
 			ext.sourceFileName = 'index.xml'
 			ext.expandPlaceholders = '**/index.xml'
 			ext.fopUserConfig = null
+			ext.retainFo = false
 			outputs.dir outputDir
 		}
 
@@ -398,7 +399,7 @@ class PdfDocbookReferenceTask extends AbstractDocbookReferenceTask {
 			}
 		}
 
-		if (!foFile.delete()) {
+		if (!project.reference.retainFo && !foFile.delete()) {
 			logger.warn("Failed to delete 'fo' file " + foFile)
 		}
 


### PR DESCRIPTION
Simplify debugging of warnings such as

`Line 1 of a paragraph overflows the available area by 4642mpt. (fo:block, location: 1612/4409)`

which includes the offset of the violating block in the fo.

```
retainFo = true
```
