### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ follows, using [spring-framework/build.gradle][2] as an example:
 ```groovy
 buildscript {
     repositories {
-        maven { url 'http://repo.spring.io/plugins-release' }
+        maven { url 'https://repo.spring.io/plugins-release' }
     }
     dependencies {
         classpath 'io.spring.gradle:docbook-reference-plugin:0.3.0'

--- a/src/main/docbook/xsl/common.xsl
+++ b/src/main/docbook/xsl/common.xsl
@@ -20,7 +20,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		exclude-result-prefixes="xslthl"
 		version='1.0'>
 

--- a/src/main/docbook/xsl/epub.xsl
+++ b/src/main/docbook/xsl/epub.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		exclude-result-prefixes="xslthl"
 		version='1.0'>
 

--- a/src/main/docbook/xsl/html.xsl
+++ b/src/main/docbook/xsl/html.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		exclude-result-prefixes="xslthl"
 		version='1.0'>
 

--- a/src/main/docbook/xsl/pdf.xsl
+++ b/src/main/docbook/xsl/pdf.xsl
@@ -22,7 +22,7 @@ under the License.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 				xmlns:d="http://docbook.org/ns/docbook"
 				xmlns:fo="http://www.w3.org/1999/XSL/Format"
-				xmlns:xslthl="http://xslthl.sf.net"
+				xmlns:xslthl="http://xslthl.sourceforge.net/"
 				exclude-result-prefixes="xslthl d"
 				version='1.0'>
 

--- a/src/main/groovy/DocbookReferencePlugin.groovy
+++ b/src/main/groovy/DocbookReferencePlugin.groovy
@@ -361,7 +361,7 @@ class PdfDocbookReferenceTask extends AbstractDocbookReferenceTask {
 	}
 
 	/**
-	 * <a href="http://xmlgraphics.apache.org/fop/0.95/embedding.html#render">From the FOP usage guide</a>
+	 * <a href="https://xmlgraphics.apache.org/fop/0.95/embedding.html#render">From the FOP usage guide</a>
 	 */
 	@Override
 	protected void postTransform(File foFile) {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://docbook.sourceforge.net/release/xsl/current/epub3/chunk.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/epub3/chunk.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/fo/highlight.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/fo/highlight.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/html/highlight.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/html/highlight.xsl) result AnnotatedConnectException).
* [ ] http://xslthl.sf.net (301) with 4 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).
* [ ] http://exslt.org/common (404) with 1 occurrences could not be migrated:  
   ([https](https://exslt.org/common) result SSLHandshakeException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://xmlgraphics.apache.org/fop/0.95/embedding.html with 1 occurrences migrated to:  
  https://xmlgraphics.apache.org/fop/0.95/embedding.html ([https](https://xmlgraphics.apache.org/fop/0.95/embedding.html) result 200).
* [ ] http://repo.spring.io/plugins-release with 1 occurrences migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 1 occurrences
* http://docbook.sourceforge.net/xmlns/l10n/1.0 with 2 occurrences
* http://www.w3.org/1999/XSL/Format with 2 occurrences
* http://www.w3.org/1999/XSL/Transform with 6 occurrences
* http://www.w3.org/1999/xhtml with 1 occurrences